### PR TITLE
fix remaining sonar issues and pin GH Actions by SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -59,7 +59,7 @@ jobs:
         run: npm run test:cov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
 
@@ -72,7 +72,7 @@ jobs:
         run: npm publish --provenance --access public --tag ${{ steps.npm-tag.outputs.tag }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/src/utils/parseJsonPath.ts
+++ b/src/utils/parseJsonPath.ts
@@ -99,6 +99,37 @@ function resolveBracketContent(bracketContent: string): string {
   return bracketContent;
 }
 
+interface PathParserState {
+  pathParts: string[];
+  currentPart: string;
+  inBrackets: boolean;
+  bracketContent: string;
+}
+
+function processPathChar(state: PathParserState, char: string): void {
+  if (char === '[') {
+    if (state.currentPart) {
+      state.pathParts.push(state.currentPart);
+      state.currentPart = '';
+    }
+    state.inBrackets = true;
+    state.bracketContent = '';
+  } else if (char === ']' && state.inBrackets) {
+    state.pathParts.push(resolveBracketContent(state.bracketContent));
+    state.inBrackets = false;
+    state.bracketContent = '';
+  } else if (char === '.' && !state.inBrackets) {
+    if (state.currentPart) {
+      state.pathParts.push(state.currentPart);
+      state.currentPart = '';
+    }
+  } else if (state.inBrackets) {
+    state.bracketContent += char;
+  } else {
+    state.currentPart += char;
+  }
+}
+
 function parseStringPath(path: string): string[] {
   const trimmedPath = validatePathInput(path);
 
@@ -108,44 +139,26 @@ function parseStringPath(path: string): string[] {
     return [normalizedPath];
   }
 
-  const pathParts: string[] = [];
-  let currentPart = '';
-  let inBrackets = false;
-  let bracketContent = '';
+  const state: PathParserState = {
+    pathParts: [],
+    currentPart: '',
+    inBrackets: false,
+    bracketContent: '',
+  };
 
   for (const char of normalizedPath) {
-    if (char === '[') {
-      if (currentPart) {
-        pathParts.push(currentPart);
-        currentPart = '';
-      }
-      inBrackets = true;
-      bracketContent = '';
-    } else if (char === ']' && inBrackets) {
-      pathParts.push(resolveBracketContent(bracketContent));
-      inBrackets = false;
-      bracketContent = '';
-    } else if (char === '.' && !inBrackets) {
-      if (currentPart) {
-        pathParts.push(currentPart);
-        currentPart = '';
-      }
-    } else if (inBrackets) {
-      bracketContent += char;
-    } else {
-      currentPart += char;
-    }
+    processPathChar(state, char);
   }
 
-  if (inBrackets) {
+  if (state.inBrackets) {
     throw new Error('Unclosed bracket in JSON path');
   }
 
-  if (currentPart) {
-    pathParts.push(currentPart);
+  if (state.currentPart) {
+    state.pathParts.push(state.currentPart);
   }
 
-  return pathParts;
+  return state.pathParts;
 }
 
 /**
@@ -200,7 +213,8 @@ export function arrayToJsonPath(pathArray: string[]): string {
         segment.includes(']') ||
         segment.includes('"')
       ) {
-        return `["${segment.replaceAll('"', String.raw`\"`)}"]`;
+        const escaped = segment.replaceAll('"', String.raw`\"`);
+        return `["${escaped}"]`;
       }
       return segment;
     })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pins GitHub Actions by SHA and refactors the JSON path parser to resolve remaining Sonar findings. Improves security and maintainability without changing behavior.

- **Dependencies**
  - Pin `actions/checkout` to v4.2.2 (SHA)
  - Pin `actions/setup-node` to v4.4.0 (SHA)
  - Pin `codecov/codecov-action` to v6.0.0 (SHA)
  - Pin `softprops/action-gh-release` to v2.6.1 (SHA)

- **Refactors**
  - Introduced `PathParserState` and `processPathChar` to simplify parsing and remove duplication.
  - Clarified string escaping in `arrayToJsonPath` via a local `escaped` variable.
  - Preserves existing behavior, including error on unclosed brackets.

<sup>Written for commit c18c8d80e3b7294d3debe2c08e2f7af4047b1feb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

